### PR TITLE
feat：界面路由与原型

### DIFF
--- a/src/components/PageBreadcrumbs.jsx
+++ b/src/components/PageBreadcrumbs.jsx
@@ -15,6 +15,8 @@ const breadcrumbsMapping = {
     '/developer/layouts': '界面',
     '/developer/streamProcess/model': '流处理服务/流数据源',
     '/developer/streamProcess/model/create': '流处理服务/流数据源/创建流数据源',
+    '/developer/streamProcess/model/data': '流处理服务/流数据源/流数据源数据',
+    '/developer/streamProcess/model/edit': '流处理服务/流数据源/编辑流数据源',
     '/developer/streamProcess/service': '流处理服务/流数据处理'
 };
 

--- a/src/components/PageBreadcrumbs.jsx
+++ b/src/components/PageBreadcrumbs.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Breadcrumb} from "antd";
+import {useLocation} from "react-router-dom";
+import {css} from "aphrodite";
+import styles from '../constants/pageStyle';
+
+// custom hook to get the current pathname in React
+export const getPathname = () => {
+    const location = useLocation();
+    console.log(location.pathname);
+    return location.pathname;
+};
+
+const breadcrumbsMapping = {
+    '/developer/layouts': '界面',
+    '/developer/streamProcess/model': '流处理服务/流数据源',
+    '/developer/streamProcess/service': '流处理服务/流数据处理'
+};
+
+const PageBreadcrumbs = ({routes}) => (
+        <Breadcrumb className={css(styles.breadCrumbs)}>
+            {breadcrumbsMapping[getPathname()] ? breadcrumbsMapping[getPathname()].split("/").map((item) => <Breadcrumb.Item>{item}</Breadcrumb.Item>) : null}
+        </Breadcrumb>
+    );
+
+export default PageBreadcrumbs;

--- a/src/components/PageBreadcrumbs.jsx
+++ b/src/components/PageBreadcrumbs.jsx
@@ -14,6 +14,7 @@ export const getPathname = () => {
 const breadcrumbsMapping = {
     '/developer/layouts': '界面',
     '/developer/streamProcess/model': '流处理服务/流数据源',
+    '/developer/streamProcess/model/create': '流处理服务/流数据源/创建流数据源',
     '/developer/streamProcess/service': '流处理服务/流数据处理'
 };
 

--- a/src/components/PageWrapper.jsx
+++ b/src/components/PageWrapper.jsx
@@ -7,6 +7,7 @@ import TitleBar from './TitleBar';
 import Footer from './Footer';
 import SiderWrapper from './SiderWrapper';
 import handleToken from '../utils/handleToken';
+import PageBreadcrumbs from "./PageBreadcrumbs";
 
 const {Content} = Layout;
 
@@ -19,6 +20,7 @@ export default function pageWrapper(items, routes, props) {
                 <SiderWrapper items={items} />
                 <Layout className={css(styles.content)}>
                     <Content className={css(styles.mainContent)}>
+                        <PageBreadcrumbs routes={routes} />
                         {routes.map((route) => (
                                 <Route
                                     exact

--- a/src/constants/pageStyle.js
+++ b/src/constants/pageStyle.js
@@ -11,9 +11,9 @@ export default StyleSheet.create({
         padding: 24,
         marginTop: 12,
         minHeight: 280,
+        margin: 24,
     },
     breadCrumbs: {
-        marginLeft: 24,
-        marginBottom: 12
+        marginBottom: 24
     }
 });

--- a/src/constants/pageStyle.js
+++ b/src/constants/pageStyle.js
@@ -12,4 +12,8 @@ export default StyleSheet.create({
         marginTop: 12,
         minHeight: 280,
     },
+    breadCrumbs: {
+        marginLeft: 24,
+        marginBottom: 12
+    }
 });

--- a/src/pages/developer/DeveloperPage.jsx
+++ b/src/pages/developer/DeveloperPage.jsx
@@ -18,6 +18,8 @@ import ModelList from './intelligence-services/model/ModelList';
 import IntelServiceList from './intelligence-services/service/ServiceList';
 import TrainPage from './intelligence-services/service/TrainPage';
 import LayoutPage from "../gui-services/layouts/LayoutPage";
+import StreamModelPage from "./stream-services/model/StreamModelPage";
+import StreamServicePage from "./stream-services/model/StreamServicePage";
 
 const routes = (match) => [
   {
@@ -109,6 +111,16 @@ const routes = (match) => [
     key: 'IntelligenceServiceTrainPage',
     path: `${match.url}/intelligence/service/train`,
     component: TrainPage,
+  },
+  {
+    key: 'streamProcessModelPage',
+    path: `${match.url}/streamProcess/model`,
+    component: StreamModelPage,
+  },
+  {
+    key: 'streamProcessServicePage',
+    path: `${match.url}/streamProcess/service`,
+    component: StreamServicePage,
   },
 ];
 

--- a/src/pages/developer/DeveloperPage.jsx
+++ b/src/pages/developer/DeveloperPage.jsx
@@ -20,6 +20,7 @@ import TrainPage from './intelligence-services/service/TrainPage';
 import LayoutPage from "../gui-services/layouts/LayoutPage";
 import StreamModelPage from "./stream-services/model/StreamModelPage";
 import StreamServicePage from "./stream-services/model/StreamServicePage";
+import StreamModelCreatePage from "./stream-services/model/StreamModelCreatePage";
 
 const routes = (match) => [
   {
@@ -116,6 +117,11 @@ const routes = (match) => [
     key: 'streamProcessModelPage',
     path: `${match.url}/streamProcess/model`,
     component: StreamModelPage,
+  },
+  {
+    key: 'streamProcessModelCreatePage',
+    path: `${match.url}/streamProcess/model/create`,
+    component: StreamModelCreatePage,
   },
   {
     key: 'streamProcessServicePage',

--- a/src/pages/developer/DeveloperPage.jsx
+++ b/src/pages/developer/DeveloperPage.jsx
@@ -21,6 +21,8 @@ import LayoutPage from "../gui-services/layouts/LayoutPage";
 import StreamModelPage from "./stream-services/model/StreamModelPage";
 import StreamServicePage from "./stream-services/model/StreamServicePage";
 import StreamModelCreatePage from "./stream-services/model/StreamModelCreatePage";
+import StreamModelDataPage from "./stream-services/model/StreamModelDataPage";
+import StreamModelEditPage from "./stream-services/model/StreamModelEditPage";
 
 const routes = (match) => [
   {
@@ -122,6 +124,16 @@ const routes = (match) => [
     key: 'streamProcessModelCreatePage',
     path: `${match.url}/streamProcess/model/create`,
     component: StreamModelCreatePage,
+  },
+  {
+    key: 'streamProcessModelDataPage',
+    path: `${match.url}/streamProcess/model/data`,
+    component: StreamModelDataPage,
+  },
+  {
+    key: 'streamProcessModelDataPage',
+    path: `${match.url}/streamProcess/model/edit`,
+    component: StreamModelEditPage,
   },
   {
     key: 'streamProcessServicePage',

--- a/src/pages/developer/stream-services/model/StreamModelCreatePage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelCreatePage.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Divider, Layout} from 'antd';
+import Title from "antd/es/typography/Title";
+
+class StreamModelCreatePage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        return (
+            <Layout>
+                <div style={{flexDirection: 'row', display: 'flex'}}>
+                    <Title level={4}>创建流数据源</Title>
+                </div>
+                <Divider />
+            </Layout>
+        );
+    }
+}
+
+export default StreamModelCreatePage;

--- a/src/pages/developer/stream-services/model/StreamModelCreatePage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelCreatePage.jsx
@@ -1,23 +1,138 @@
 import React from 'react';
-import {Divider, Layout} from 'antd';
+import {
+Button, Divider, Form, Icon, Input, Layout, List, Select, Switch, Tag
+} from 'antd';
 import Title from "antd/es/typography/Title";
+import Text from "antd/es/typography/Text";
+import {CloseCircleOutlined, TagOutlined} from "@ant-design/icons";
+import {getColorByType} from "../../../gui-services/customizer/api-util/TypeTree";
+import history from "../../../../utils/history";
 
 class StreamModelCreatePage extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {};
+        this.state = {
+            isTimeStamp: true
+        };
     }
 
     render() {
+        const {getFieldDecorator} = this.props.form;
+
         return (
             <Layout>
                 <div style={{flexDirection: 'row', display: 'flex'}}>
                     <Title level={4}>创建流数据源</Title>
                 </div>
                 <Divider />
+                <Form style={{
+                    width: "400px", margin: "auto", display: "flex", flexDirection: "column"
+                }}
+                >
+                    <Form.Item label="数据源名称">
+                        {getFieldDecorator('className', {
+                            rules: [
+                                {
+                                    required: true,
+                                    message: "必须填写数据源名称！"
+                                }
+                            ]
+                        })}
+                        <Input placeholder="请输入数据源名称" />
+                    </Form.Item>
+                    <div style={{
+                        display: "flex", flexDirection: "row", justifyContent: "space-around"
+                    }}
+                    >
+                        <div style={{display: "flex", flexDirection: "column", flex: 3}}>
+                            <Form.Item label="是否使用时间戳">
+                                <div>
+                                    <Switch
+                                        checked={this.state.isTimeStamp}
+                                        onChange={(checked) => {
+                                            this.setState({isTimeStamp: checked});
+                                        }}
+                                    />
+                                </div>
+                            </Form.Item>
+                        </div>
+                        <div style={{display: "flex", flexDirection: "column", flex: 7}}>
+                            <Form.Item label="时间戳名称">
+                                {getFieldDecorator('timeStampName', {
+                                    rules: [
+                                        {
+                                            required: this.state.isTimeStamp,
+                                            message: "必须填写时间戳名称！"
+                                        }
+                                    ]
+                                })}
+                                <Input placeholder="请输入时间戳名称" />
+                            </Form.Item>
+                        </div>
+                    </div>
+                    <Form.Item label="DataSource Id">
+                        {getFieldDecorator('dataSourceId', {
+                            rules: [
+                                {
+                                    required: true,
+                                    message: "必须选择DataSource Id！"
+                                }
+                            ]
+                        })}
+                        <Select />
+                    </Form.Item>
+                    <Text strong style={{marginBottom: 10}}>数据源属性列表</Text>
+                    <List
+                        bordered
+                        size="small"
+                        renderItem={(item, index) => (
+                            <List.Item key={index} style={{display: 'flex'}}>
+                                <Tag color={getColorByType(item.type)}>
+                                    <TagOutlined />
+                                </Tag>
+                                <Divider type="vertical" />
+                                {item.name}
+                                <Divider type="vertical" />
+                                <CloseCircleOutlined
+                                    style={{color: 'red', fontSize: '20px'}}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                    }}
+                                />
+                            </List.Item>
+                        )}
+                    />
+                    <Button
+                        type="dashed"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            // this.add(componentData);
+                        }}
+                        style={{width: '100%', marginTop: '20px'}}
+                    >
+                        <Icon type="plus" />
+                        创建
+                    </Button>
+                    <div style={{
+                        flexDirection: 'row-reverse', display: "flex", marginTop: 80, justifyContent: "space-around"
+                    }}
+                    >
+                        <Button
+                            type="primary"
+                            icon="form"
+                            onClick={() => {
+                                history.push("/developer/streamProcess/model/create");
+                            }}
+                        >
+                            创建
+                        </Button>
+                        <Button icon="close">取消</Button>
+                    </div>
+                </Form>
             </Layout>
         );
     }
 }
 
+StreamModelCreatePage = Form.create({name: 'stream_model_create_page'})(StreamModelCreatePage);
 export default StreamModelCreatePage;

--- a/src/pages/developer/stream-services/model/StreamModelDataPage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelDataPage.jsx
@@ -3,12 +3,10 @@ import {
 Button, Divider, Layout, Table, Tag
 } from 'antd';
 import Title from "antd/es/typography/Title";
-import {NavLink} from "react-router-dom";
-import history from '../../../../utils/history';
+import Column from "antd/es/table/Column";
+import history from "../../../../utils/history";
 
-const {Column} = Table;
-
-class StreamModelPage extends React.Component {
+class StreamModelDataPage extends React.Component {
     constructor(props) {
         super(props);
         this.state = {};
@@ -36,7 +34,7 @@ class StreamModelPage extends React.Component {
         return (
             <Layout>
                 <div style={{flexDirection: 'row', display: 'flex'}}>
-                    <Title level={4}>流数据源</Title>
+                    <Title level={4}>流数据源数据</Title>
                     <Button
                         type="primary"
                         style={{marginLeft: "auto"}}
@@ -73,17 +71,7 @@ class StreamModelPage extends React.Component {
                         key="action"
                         render={(text, record) => (
                             <span>
-                                <Button>
-                                    <NavLink to="/developer/streamProcess/model/data">
-                                        查看
-                                    </NavLink>
-                                </Button>
-                                <Divider type="vertical" />
-                                <Button>
-                                    <NavLink to="/developer/streamProcess/model/edit">
-                                        编辑
-                                    </NavLink>
-                                </Button>
+                                <Button>编辑</Button>
                                 <Divider type="vertical" />
                                 <Button type="danger">删除</Button>
                             </span>
@@ -95,4 +83,4 @@ class StreamModelPage extends React.Component {
     }
 }
 
-export default StreamModelPage;
+export default StreamModelDataPage;

--- a/src/pages/developer/stream-services/model/StreamModelEditPage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelEditPage.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Divider, Layout} from 'antd';
+import Title from "antd/es/typography/Title";
+
+class StreamModelDataPage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        return (
+            <Layout>
+                <div style={{flexDirection: 'row', display: 'flex'}}>
+                    <Title level={4}>编辑流数据源</Title>
+                </div>
+                <Divider />
+            </Layout>
+        );
+    }
+}
+
+export default StreamModelDataPage;

--- a/src/pages/developer/stream-services/model/StreamModelPage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelPage.jsx
@@ -3,6 +3,7 @@ import {
 Button, Divider, Layout, Table, Tag
 } from 'antd';
 import Title from "antd/es/typography/Title";
+import {NavLink} from "react-router-dom";
 
 const {Column} = Table;
 
@@ -35,7 +36,11 @@ class StreamModelPage extends React.Component {
             <Layout>
                 <div style={{flexDirection: 'row', display: 'flex'}}>
                     <Title level={4}>流数据源</Title>
-                    <Button type="primary" style={{marginLeft: "auto"}} icon="form">创建</Button>
+                    <Button type="primary" style={{marginLeft: "auto"}} icon="form">
+                        <NavLink to="/developer/streamProcess/model/create">
+                            创建
+                        </NavLink>
+                    </Button>
                 </div>
                 <Divider />
                 <Table dataSource={data} size="small">
@@ -58,13 +63,13 @@ class StreamModelPage extends React.Component {
                         )}
                     />
                     <Column
-                        title="Action"
+                        title="操作"
                         key="action"
                         render={(text, record) => (
                             <span>
-                                <Button>{record.lastName}</Button>
+                                <Button>编辑</Button>
                                 <Divider type="vertical" />
-                                <Button type="danger">Delete</Button>
+                                <Button type="danger">删除</Button>
                             </span>
                         )}
                     />

--- a/src/pages/developer/stream-services/model/StreamModelPage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelPage.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {Layout} from 'antd';
+import {
+Button, Divider, Layout, Table, Tag
+} from 'antd';
+import Title from "antd/es/typography/Title";
+
+const {Column} = Table;
 
 class StreamModelPage extends React.Component {
     constructor(props) {
@@ -8,8 +13,63 @@ class StreamModelPage extends React.Component {
     }
 
     render() {
+        const data = [{
+            key: '1',
+            firstName: 'John',
+            lastName: 'Brown',
+            age: 32,
+            address: 'New York No. 1 Lake Park',
+            tags: ['nice', 'developer'],
+        }, {
+            key: '2', firstName: 'Jim', lastName: 'Green', age: 42, address: 'London No. 1 Lake Park', tags: ['loser'],
+        }, {
+            key: '3',
+            firstName: 'Joe',
+            lastName: 'Black',
+            age: 32,
+            address: 'Sidney No. 1 Lake Park',
+            tags: ['cool', 'teacher'],
+        }];
+
         return (
-            <Layout />
+            <Layout>
+                <div style={{flexDirection: 'row', display: 'flex'}}>
+                    <Title level={4}>流数据源</Title>
+                    <Button type="primary" style={{marginLeft: "auto"}} icon="form">创建</Button>
+                </div>
+                <Divider />
+                <Table dataSource={data} size="small">
+                    <Column title="First Name" dataIndex="firstName" key="firstName" />
+                    <Column title="Last Name" dataIndex="lastName" key="lastName" />
+                    <Column title="Age" dataIndex="age" key="age" />
+                    <Column title="Address" dataIndex="address" key="address" />
+                    <Column
+                        title="Tags"
+                        dataIndex="tags"
+                        key="tags"
+                        render={tags => (
+                            <span>
+                                {tags.map(tag => (
+                                    <Tag color="blue" key={tag}>
+                                        {tag}
+                                    </Tag>
+                                ))}
+                            </span>
+                        )}
+                    />
+                    <Column
+                        title="Action"
+                        key="action"
+                        render={(text, record) => (
+                            <span>
+                                <Button>{record.lastName}</Button>
+                                <Divider type="vertical" />
+                                <Button type="danger">Delete</Button>
+                            </span>
+                        )}
+                    />
+                </Table>
+            </Layout>
         );
     }
 }

--- a/src/pages/developer/stream-services/model/StreamModelPage.jsx
+++ b/src/pages/developer/stream-services/model/StreamModelPage.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {Layout} from 'antd';
+
+class StreamModelPage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        return (
+            <Layout />
+        );
+    }
+}
+
+export default StreamModelPage;

--- a/src/pages/developer/stream-services/model/StreamServicePage.jsx
+++ b/src/pages/developer/stream-services/model/StreamServicePage.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {Layout} from 'antd';
+
+class StreamServicePage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        return (
+            <Layout />
+        );
+    }
+}
+
+export default StreamServicePage;


### PR DESCRIPTION
新增内容：
- 数据源几个界面之间的路由
- #2 （100%）
![image](https://user-images.githubusercontent.com/41462684/204237554-c52bcd4d-9e28-4772-9ad8-4867c5a30215.png)
- #1 （100%）
![image](https://user-images.githubusercontent.com/41462684/204237815-51ad68ac-92a6-4a6e-bf58-7975be61aacc.png)
- #3  （100%）
![image](https://user-images.githubusercontent.com/41462684/204237917-7aaaa8d7-912f-40c0-8e1b-1ce186edd463.png)

TODO：
- 上述界面与后端数据的集成
- 界面的测试
- 新增数据源数据就界面